### PR TITLE
Introduce public max length fields for SelectOption

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
@@ -30,6 +30,21 @@ import javax.annotation.Nullable;
  */
 public class SelectOption implements SerializableData
 {
+    /**
+     * The maximum length a select option label can have
+     */
+    public static final int LABEL_MAX_LENGTH = 25;
+
+    /**
+     * The maximum length a select option value can have
+     */
+    public static final int VALUE_MAX_LENGTH = 100;
+
+    /**
+     * The maximum length a select option description can have
+     */
+    public static final int DESCRIPTION_MAX_LENGTH = 50;
+
     private final String label, value;
     private final String description;
     private final boolean isDefault;
@@ -72,10 +87,10 @@ public class SelectOption implements SerializableData
     {
         Checks.notEmpty(label, "Label");
         Checks.notEmpty(value, "Value");
-        Checks.notLonger(label, 25, "Label");
-        Checks.notLonger(value, 100, "Value");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
+        Checks.notLonger(value, VALUE_MAX_LENGTH, "Value");
         if (description != null)
-            Checks.notLonger(description, 50, "Description");
+            Checks.notLonger(description, DESCRIPTION_MAX_LENGTH, "Description");
         this.label = label;
         this.value = value;
         this.description = description;


### PR DESCRIPTION
## Pull Request Etiquette

- [/] I have checked the PRs for upcoming features/bug fixes.
- [/] I have read the [contributing guidelines][contributing].

### Changes

- [/] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

Introduces public fields in SelectOption that contain the maximum length of Label, Value and Description. Identical to MessageEmbed, these fields can then be used by developers without having to update themselves when changes occur.
